### PR TITLE
Fix authentication to use HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Add this to your Claude Desktop configuration file:
       "command": "npx",
       "args": ["t212-mcp-server"],
       "env": {
-        "T212_API_KEY": "your-trading212-api-key"
+        "T212_API_KEY": "your-trading212-api-key-id",
+        "T212_API_SECRET": "your-trading212-api-secret"
       }
     }
   }
@@ -55,7 +56,8 @@ npm install -g t212-mcp-server
     "t212-mcp": {
       "command": "t212-mcp-server",
       "env": {
-        "T212_API_KEY": "your-trading212-api-key"
+        "T212_API_KEY": "your-trading212-api-key-id",
+        "T212_API_SECRET": "your-trading212-api-secret"
       }
     }
   }
@@ -71,12 +73,13 @@ npm install -g t212-mcp-server
 
 For detailed configuration instructions, see the [official MCP documentation](https://modelcontextprotocol.io/quickstart/user).
 
-## Getting your Trading212 API Key
+## Getting your Trading212 API Credentials
 
 1. Log into your Trading212 account
-2. Navigate to Settings → API 
+2. Navigate to Settings → API
 3. Generate a new API key
-4. Copy the key and use it in your configuration
+4. Copy both the **API Key ID** and the **Secret Key** (the secret is only shown at creation time)
+5. Use both values in your configuration as `T212_API_KEY` and `T212_API_SECRET`
 
 ## Available Tools
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,18 +4,23 @@ import type {AccountCash, AccountMetadata} from "../models/Account.js"
 
 const API_BASE = "https://live.trading212.com/api/v0"
 const API_KEY = process.env.T212_API_KEY ?? ""
+const API_SECRET = process.env.T212_API_SECRET ?? ""
 
 const USER_AGENT = "T212-mcp/1.0"
 
 async function fetchResource<T>(resourcePath: string): Promise<T | null> {
   if (API_KEY.length == 0) {
-    throw Error("No API key found")
+    throw Error("No API key found. Set T212_API_KEY environment variable.")
+  }
+  if (API_SECRET.length == 0) {
+    throw Error("No API secret found. Set T212_API_SECRET environment variable.")
   }
 
+  const credentials = btoa(`${API_KEY}:${API_SECRET}`)
   const headers = {
     "User-Agent": USER_AGENT,
     Accept: "application/json",
-    Authorization: API_KEY
+    Authorization: `Basic ${credentials}`
   };
 
   try {


### PR DESCRIPTION
## Summary
- Trading 212 updated their API to require HTTP Basic Authentication with both an API Key ID and Secret Key (Base64-encoded as `key:secret`)
- The current code sends the raw API key in the `Authorization` header, which returns `401 Unauthorized`
- This PR updates authentication to use `Authorization: Basic <base64(key:secret)>` and adds a new `T212_API_SECRET` environment variable

Fixes #1 and #3.

## Changes
- **`src/api/api.ts`**: Read `T212_API_SECRET` env var, Base64-encode `key:secret`, send as `Basic` auth header
- **`README.md`**: Updated configuration examples and setup instructions to include `T212_API_SECRET`

## Test plan
- [x] Verified API returns `401` with raw key auth (old behaviour)
- [x] Verified API returns `200` with Basic auth using key + secret (new behaviour)
- [x] Project builds cleanly with `npm run build`